### PR TITLE
fix(swa): replace unsupported '{*path}' wildcard with '/*' in API routes

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,14 +1,14 @@
 {
   "routes": [
     {
-      "route": "/api/actuator/{*path}",
+      "route": "/api/actuator/*",
       "rewrite": "/actuator/{path}",
       "allowedRoles": [
         "anonymous"
       ]
     },
     {
-      "route": "/api/{*path}",
+      "route": "/api/*",
       "allowedRoles": [
         "anonymous"
       ]


### PR DESCRIPTION
- Fixed route '/api/actuator/{*path}' to '/api/actuator/*'
- Fixed route '/api/{*path}' to '/api/*'
- Resolves Azure Static Web Apps configuration validation error